### PR TITLE
Add PodLogs and PodMonitor for observability

### DIFF
--- a/charts/karpenter/templates/podlogs.yaml
+++ b/charts/karpenter/templates/podlogs.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.podLogs.enabled }}
+apiVersion: monitoring.grafana.com/v1alpha2
+kind: PodLogs
+metadata:
+  name: {{ include "karpenter.fullname" $ }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "karpenter.labels" $ | nindent 4 }}
+  {{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: {{ $.Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "karpenter.selectorLabels" $ | nindent 6 }}
+  relabelings:
+  - action: replace
+    replacement: {{ .Values.podLogs.tenant }}
+    targetLabel: giantswarm_observability_tenant
+{{- end }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -28,18 +28,6 @@ additionalClusterRoleRules: []
 serviceMonitor:
   # -- Specifies whether a ServiceMonitor should be created.
   enabled: false
-  # -- Additional labels for the ServiceMonitor.
-  additionalLabels: {}
-  # -- Relabelings for the `http-metrics` endpoint on the ServiceMonitor.
-  # For more details on relabelings, see: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
-  relabelings: []
-  # -- Metric relabelings for the `http-metrics` endpoint on the ServiceMonitor.
-  # For more details on metric relabelings, see: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
-  metricRelabelings: []
-  # -- Configuration on `http-metrics` endpoint for the ServiceMonitor.
-  # Not to be used to add additional endpoints.
-  # See the Prometheus operator documentation for configurable fields https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#endpoint
-  endpointConfig: {}
 # -- Number of replicas.
 replicas: 2
 # -- The number of old ReplicaSets to retain to allow rollback.
@@ -52,6 +40,12 @@ strategy:
 podLabels: {}
 # -- Additional annotations for the pod.
 podAnnotations: {}
+podLogs:
+  # -- Specifies whether a PodLogs resource should be created for log collection.
+  enabled: false
+  # -- The tenant name for routing logs to the correct Grafana organization.
+  # Must match a tenant configured in your observability platform.
+  tenant: ""
 podDisruptionBudget:
   name: karpenter
   maxUnavailable: 1


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/35512

## Summary

- Add `PodLogs` custom resource (monitoring.grafana.com/v1alpha2) for log collection with tenant-based routing
- Add `PodMonitor` custom resource (monitoring.coreos.com/v1) for direct pod metrics collection
- Both resources are disabled by default and can be enabled via Helm values

## Configuration

Enable via values.yaml:

```yaml
podLogs:
  enabled: true
  tenant: "your-tenant-name"

podMonitor:
  enabled: true
```

## Test plan

- [ ] Verify templates render correctly with `helm template`
- [ ] Deploy to test cluster with observability stack
- [ ] Confirm logs appear in Grafana with correct tenant
- [ ] Confirm metrics are scraped via PodMonitor